### PR TITLE
Fix decision

### DIFF
--- a/src/decision/CMakeLists.txt
+++ b/src/decision/CMakeLists.txt
@@ -83,17 +83,14 @@ target_link_libraries(decision_node ${catkin_LIBRARIES})
 # endif()
 if (CATKIN_ENABLE_TESTING)
 
-#    # Adding gtests to the package
-#    catkin_add_gtest(my-node-test test/my-node-test.cpp src/MyNode.cpp)
-#    target_link_libraries(my-node-test ${catkin_LIBRARIES})
-#
-#    # Adding rostest to the package
-#    find_package(rostest REQUIRED)
-#    # name the test and link it to the .test file and the .cpp file itself, this will allow
-#    # "catkin_make run_tests" to be able to find and run this rostest
-#    add_rostest_gtest(my_node_rostest test/sample_package_test.test test/my_node_rostest.cpp)
-#    target_link_libraries(my_node_rostest ${catkin_LIBRARIES})
-endif()
+    find_package(rostest REQUIRED)
 
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+    add_rostest_gtest(
+            decision_node_rostest
+            test/decision_node_test.test
+            test/decision_node_rostest.cpp
+    )
+
+    target_link_libraries(decision_node_rostest ${catkin_LIBRARIES})
+
+endif()

--- a/src/decision/include/DecisionNode.h
+++ b/src/decision/include/DecisionNode.h
@@ -26,7 +26,6 @@ typedef int8_t state_t;
 class DecisionNode {
   public:
     DecisionNode(int argc, char** argv, std::string node_name);
-    const char* logger_name = ROSCONSOLE_DEFAULT_NAME ".<name>";
 
   private:
     std::unordered_map<state_t, Subroutine*>

--- a/src/decision/include/DecisionNode.h
+++ b/src/decision/include/DecisionNode.h
@@ -34,6 +34,9 @@ class DecisionNode {
     Subroutine* running_; // the currently running subroutine
     ros::Subscriber worldstate_subscriber_; // subscribes to the world state
 
+    // says which subroutine is running, for testing & debugging
+    ros::Publisher info_publisher_;
+
     /**
      * Callback function when a message is received from the world state node.
      * @param state_msg message containing the current state

--- a/src/decision/include/DecisionNode.h
+++ b/src/decision/include/DecisionNode.h
@@ -42,11 +42,7 @@ class DecisionNode {
     /**
      * Sets up the map "subroutines_" such that each enumerated state is mapped
      * to its appropriate subroutine.
-     * @param argc standard argc passed in from main, used for the ros::init of
-     * each subroutine
-     * @param argv standard argv passed in from main, used for the ros::init of
-     * each subroutine
      */
-    void setupSubroutineMap(int argc, char** argv);
+    void setupSubroutineMap();
 };
 #endif // DECISION_DECISION_H_H

--- a/src/decision/include/DecisionNode.h
+++ b/src/decision/include/DecisionNode.h
@@ -26,6 +26,7 @@ typedef int8_t state_t;
 class DecisionNode {
   public:
     DecisionNode(int argc, char** argv, std::string node_name);
+    const char* logger_name = ROSCONSOLE_DEFAULT_NAME ".<name>";
 
   private:
     std::unordered_map<state_t, Subroutine*>

--- a/src/decision/include/subroutines/Subroutine.h
+++ b/src/decision/include/subroutines/Subroutine.h
@@ -51,11 +51,14 @@ class Subroutine {
     geometry_msgs::Vector3 makeVector(double x, double y, double z);
 
     /**
-     * Gets the subscriptions for the subroutine. Each implementing class of subroutine is responsible for having this function return all subscriber objects it needs to work.
+     * Gets the subscriptions for the subroutine. Each implementing class of
+     * subroutine is responsible for having this function return all subscriber
+     * objects it needs to work.
      * @param nh node handle used to create the subscribers
      * @return a vector of all subscriptions the subroutine needs
      */
-    virtual std::vector<ros::Subscriber> getSubscriptions(ros::NodeHandle nh) = 0;
+    virtual std::vector<ros::Subscriber>
+    getSubscriptions(ros::NodeHandle nh) = 0;
 };
 
 #endif // DECISION_SUBROUTINE_H

--- a/src/decision/include/subroutines/Subroutine.h
+++ b/src/decision/include/subroutines/Subroutine.h
@@ -24,6 +24,7 @@ static const double DOWN     = -0.25;
 class Subroutine {
   public:
     Subroutine();
+    virtual std::string getName() = 0;
 
     void startup();
     void shutdown();

--- a/src/decision/include/subroutines/Subroutine.h
+++ b/src/decision/include/subroutines/Subroutine.h
@@ -23,13 +23,15 @@ static const double DOWN     = -1.0;
 
 class Subroutine {
   public:
-    Subroutine(int argc, char** argv, std::string node_name);
+    Subroutine();
 
     void startup();
     void shutdown();
 
   protected:
     ros::Publisher publisher_;
+    ros::NodeHandle nh_;
+    ros::NodeHandle private_nh_;
     void publishCommand(const geometry_msgs::Twist& msg);
     geometry_msgs::Vector3 makeVector(double x, double y, double z);
 

--- a/src/decision/include/subroutines/Subroutine.h
+++ b/src/decision/include/subroutines/Subroutine.h
@@ -14,12 +14,12 @@
  * pre defined directions for subroutines to use
  * example: z_rotation = RIGHT
  */
-static const double RIGHT    = -1.0;
-static const double LEFT     = 1.0;
-static const double FORWARD  = 1.0;
-static const double BACKWARD = -1.0;
-static const double UP       = 1.0;
-static const double DOWN     = -1.0;
+static const double RIGHT    = -0.25;
+static const double LEFT     = 0.25;
+static const double FORWARD  = 0.25;
+static const double BACKWARD = -0.25;
+static const double UP       = 0.25;
+static const double DOWN     = -0.25;
 
 class Subroutine {
   public:

--- a/src/decision/include/subroutines/Subroutine.h
+++ b/src/decision/include/subroutines/Subroutine.h
@@ -22,6 +22,11 @@ static const double UP       = 0.25;
 static const double DOWN     = -0.25;
 
 class Subroutine {
+  private:
+    // hold onto these, automatically unsubscribe/unadvertise when out of scope
+    ros::Publisher publisher_;
+    std::vector<ros::Subscriber> subscriptions_;
+
   public:
     Subroutine();
     virtual std::string getName() = 0;
@@ -30,14 +35,27 @@ class Subroutine {
     void shutdown();
 
   protected:
-    // hold onto these, automatically unsubscribe/unadvertise when out of scope
-    ros::Publisher publisher_;
-    std::vector<ros::Subscriber> subscriptions_;
-
+    /**
+     * Publishes a Twist message containing the movement decision
+     * @param msg
+     */
     void publishCommand(const geometry_msgs::Twist& msg);
+
+    /**
+     * Utility function for creating a geometry_msgs::Vector3
+     * @param x
+     * @param y
+     * @param z
+     * @return x, y and z in order in a Vector3
+     */
     geometry_msgs::Vector3 makeVector(double x, double y, double z);
 
-    virtual void setupSubscriptions(ros::NodeHandle nh) = 0;
+    /**
+     * Gets the subscriptions for the subroutine. Each implementing class of subroutine is responsible for having this function return all subscriber objects it needs to work.
+     * @param nh node handle used to create the subscribers
+     * @return a vector of all subscriptions the subroutine needs
+     */
+    virtual std::vector<ros::Subscriber> getSubscriptions(ros::NodeHandle nh) = 0;
 };
 
 #endif // DECISION_SUBROUTINE_H

--- a/src/decision/include/subroutines/Subroutine.h
+++ b/src/decision/include/subroutines/Subroutine.h
@@ -29,11 +29,9 @@ class Subroutine {
     void shutdown();
 
   protected:
+    // hold onto these, automatically unsubscribe/unadvertise when out of scope
     ros::Publisher publisher_;
-
-    // these are used to set up and tear down routine specific subs/pubs
-    ros::NodeHandle nh_;
-    ros::NodeHandle private_nh_;
+    ros::Subscriber subscriber_;
 
     void publishCommand(const geometry_msgs::Twist& msg);
     geometry_msgs::Vector3 makeVector(double x, double y, double z);

--- a/src/decision/include/subroutines/Subroutine.h
+++ b/src/decision/include/subroutines/Subroutine.h
@@ -32,7 +32,7 @@ class Subroutine {
   protected:
     // hold onto these, automatically unsubscribe/unadvertise when out of scope
     ros::Publisher publisher_;
-    ros::Subscriber subscriber_;
+    std::vector<ros::Subscriber> subscriptions_;
 
     void publishCommand(const geometry_msgs::Twist& msg);
     geometry_msgs::Vector3 makeVector(double x, double y, double z);

--- a/src/decision/include/subroutines/Subroutine.h
+++ b/src/decision/include/subroutines/Subroutine.h
@@ -30,8 +30,11 @@ class Subroutine {
 
   protected:
     ros::Publisher publisher_;
+
+    // these are used to set up and tear down routine specific subs/pubs
     ros::NodeHandle nh_;
     ros::NodeHandle private_nh_;
+
     void publishCommand(const geometry_msgs::Twist& msg);
     geometry_msgs::Vector3 makeVector(double x, double y, double z);
 

--- a/src/decision/include/subroutines/gate/GoThroughGate.h
+++ b/src/decision/include/subroutines/gate/GoThroughGate.h
@@ -18,8 +18,7 @@
  */
 class GoThroughGate : public Subroutine {
   public:
-    GoThroughGate(int argc, char** argv, std::string node_name)
-      : Subroutine(argc, argv, node_name) {}
+    GoThroughGate() : Subroutine() {}
     void setupSubscriptions(ros::NodeHandle nh) override;
 
   private:

--- a/src/decision/include/subroutines/gate/GoThroughGate.h
+++ b/src/decision/include/subroutines/gate/GoThroughGate.h
@@ -19,6 +19,10 @@
 class GoThroughGate : public Subroutine {
   public:
     GoThroughGate() : Subroutine() {}
+    std::string getName() override {
+        return "GoThroughGate";
+    }
+
     void setupSubscriptions(ros::NodeHandle nh) override;
 
   private:

--- a/src/decision/include/subroutines/gate/GoThroughGate.h
+++ b/src/decision/include/subroutines/gate/GoThroughGate.h
@@ -19,9 +19,7 @@
 class GoThroughGate : public Subroutine {
   public:
     GoThroughGate() : Subroutine() {}
-    std::string getName() override {
-        return "GoThroughGate";
-    }
+    std::string getName() override { return "GoThroughGate"; }
 
     void setupSubscriptions(ros::NodeHandle nh) override;
 

--- a/src/decision/include/subroutines/gate/GoThroughGate.h
+++ b/src/decision/include/subroutines/gate/GoThroughGate.h
@@ -21,7 +21,7 @@ class GoThroughGate : public Subroutine {
     GoThroughGate() : Subroutine() {}
     std::string getName() override { return "GoThroughGate"; }
 
-    void setupSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber> getSubscriptions(ros::NodeHandle nh) override;
 
   private:
     void decisionCallback(const gate_detect::gateDetectMsg::ConstPtr& msg);

--- a/src/decision/include/subroutines/gate/LineUpWithGate.h
+++ b/src/decision/include/subroutines/gate/LineUpWithGate.h
@@ -19,8 +19,7 @@
  */
 class LineUpWithGate : public Subroutine {
   public:
-    LineUpWithGate(int argc, char** argv, std::string node_name)
-      : Subroutine(argc, argv, node_name) {}
+    LineUpWithGate() : Subroutine() {}
     void setupSubscriptions(ros::NodeHandle nh) override;
 
   private:

--- a/src/decision/include/subroutines/gate/LineUpWithGate.h
+++ b/src/decision/include/subroutines/gate/LineUpWithGate.h
@@ -25,7 +25,7 @@ class LineUpWithGate : public Subroutine {
     void setupSubscriptions(ros::NodeHandle nh) override;
 
   private:
-    bool allignTop_ = false, distanceToGateAcceptable_ = false;
+    bool align_top_ = false, distance_to_gate_acceptable_ = false;
     void decisionCallback(const gate_detect::gateDetectMsg::ConstPtr& msg);
     void balance(const geometry_msgs::Twist::ConstPtr& msg);
 };

--- a/src/decision/include/subroutines/gate/LineUpWithGate.h
+++ b/src/decision/include/subroutines/gate/LineUpWithGate.h
@@ -22,12 +22,11 @@ class LineUpWithGate : public Subroutine {
     LineUpWithGate() : Subroutine() {}
     std::string getName() override { return "LineUpWithGate"; }
 
-    void setupSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber> getSubscriptions(ros::NodeHandle nh) override;
 
   private:
     bool align_top_ = false, distance_to_gate_acceptable_ = false;
     void decisionCallback(const gate_detect::gateDetectMsg::ConstPtr& msg);
-    void balance(const geometry_msgs::Twist::ConstPtr& msg);
 };
 
 #endif // DECISION_LINEUPWITHGATE_H

--- a/src/decision/include/subroutines/gate/LineUpWithGate.h
+++ b/src/decision/include/subroutines/gate/LineUpWithGate.h
@@ -20,9 +20,7 @@
 class LineUpWithGate : public Subroutine {
   public:
     LineUpWithGate() : Subroutine() {}
-    std::string getName() override {
-        return "LineUpWithGate";
-    }
+    std::string getName() override { return "LineUpWithGate"; }
 
     void setupSubscriptions(ros::NodeHandle nh) override;
 

--- a/src/decision/include/subroutines/gate/LineUpWithGate.h
+++ b/src/decision/include/subroutines/gate/LineUpWithGate.h
@@ -20,6 +20,10 @@
 class LineUpWithGate : public Subroutine {
   public:
     LineUpWithGate() : Subroutine() {}
+    std::string getName() override {
+        return "LineUpWithGate";
+    }
+
     void setupSubscriptions(ros::NodeHandle nh) override;
 
   private:

--- a/src/decision/include/subroutines/gate/LineUpWithGate.h
+++ b/src/decision/include/subroutines/gate/LineUpWithGate.h
@@ -23,6 +23,7 @@ class LineUpWithGate : public Subroutine {
     void setupSubscriptions(ros::NodeHandle nh) override;
 
   private:
+    bool allignTop_ = false, distanceToGateAcceptable_ = false;
     void decisionCallback(const gate_detect::gateDetectMsg::ConstPtr& msg);
     void balance(const geometry_msgs::Twist::ConstPtr& msg);
 };

--- a/src/decision/include/subroutines/gate/LocateGate.h
+++ b/src/decision/include/subroutines/gate/LocateGate.h
@@ -20,9 +20,7 @@
 class LocateGate : public Subroutine {
   public:
     LocateGate() : Subroutine() {}
-    std::string getName() override {
-        return "LocateGate";
-    }
+    std::string getName() override { return "LocateGate"; }
 
     void setupSubscriptions(ros::NodeHandle nh) override;
 

--- a/src/decision/include/subroutines/gate/LocateGate.h
+++ b/src/decision/include/subroutines/gate/LocateGate.h
@@ -19,8 +19,7 @@
  */
 class LocateGate : public Subroutine {
   public:
-    LocateGate(int argc, char** argv, std::string node_name)
-      : Subroutine(argc, argv, node_name) {}
+    LocateGate() : Subroutine() {}
     void setupSubscriptions(ros::NodeHandle nh) override;
 
   private:

--- a/src/decision/include/subroutines/gate/LocateGate.h
+++ b/src/decision/include/subroutines/gate/LocateGate.h
@@ -22,7 +22,7 @@ class LocateGate : public Subroutine {
     LocateGate() : Subroutine() {}
     std::string getName() override { return "LocateGate"; }
 
-    void setupSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber> getSubscriptions(ros::NodeHandle nh) override;
 
   private:
     void decisionCallback(const gate_detect::gateDetectMsg::ConstPtr& msg);

--- a/src/decision/include/subroutines/gate/LocateGate.h
+++ b/src/decision/include/subroutines/gate/LocateGate.h
@@ -20,6 +20,10 @@
 class LocateGate : public Subroutine {
   public:
     LocateGate() : Subroutine() {}
+    std::string getName() override {
+        return "LocateGate";
+    }
+
     void setupSubscriptions(ros::NodeHandle nh) override;
 
   private:

--- a/src/decision/src/DecisionNode.cpp
+++ b/src/decision/src/DecisionNode.cpp
@@ -9,11 +9,11 @@
 #include "DecisionNode.h"
 
 DecisionNode::DecisionNode(int argc, char** argv, std::string node_name) {
-    setupSubroutineMap(argc, argv);
-
     ros::init(argc, argv, node_name);
     ros::NodeHandle nh;
     ros::NodeHandle private_nh("~");
+
+    setupSubroutineMap(argc, argv);
 
     std::string state_topic = "worldstate";
     int refresh_rate        = 10;
@@ -54,12 +54,7 @@ const worldstate::StateMsg::ConstPtr& StateMsg) {
  * subroutine
  */
 void DecisionNode::setupSubroutineMap(int argc, char** argv) {
-    subroutines_[worldstate::StateMsg::locatingGate] =
-    new LocateGate(argc, argv, "locate_gate");
-
-    subroutines_[worldstate::StateMsg::aligningWithGate] =
-    new LineUpWithGate(argc, argv, "align_with_gate");
-
-    subroutines_[worldstate::StateMsg::passingGate] =
-    new GoThroughGate(argc, argv, "go_through_gate");
+    subroutines_[worldstate::StateMsg::locatingGate] = new LocateGate();
+    subroutines_[worldstate::StateMsg::aligningWithGate] = new LineUpWithGate();
+    subroutines_[worldstate::StateMsg::passingGate] = new GoThroughGate();
 }

--- a/src/decision/src/DecisionNode.cpp
+++ b/src/decision/src/DecisionNode.cpp
@@ -29,6 +29,8 @@ void DecisionNode::worldStateCallback(
 const worldstate::StateMsg::ConstPtr& StateMsg) {
     state_t state = StateMsg->state;
 
+    std::string s = std::to_string(state);
+
     if (subroutines_.find(state) == subroutines_.end()) {
         // We forgot to add a subroutine to the map. This is bad.
 
@@ -38,11 +40,11 @@ const worldstate::StateMsg::ConstPtr& StateMsg) {
     }
 
     Subroutine* newState = subroutines_[state];
-    if (newState == running_) { return; }
-
-    running_->shutdown();
-    running_ = newState;
-    running_->startup();
+    if (newState != running_) {
+        running_->shutdown();
+        running_ = newState;
+        running_->startup();
+    }
 }
 
 /**
@@ -57,4 +59,7 @@ void DecisionNode::setupSubroutineMap() {
     subroutines_[worldstate::StateMsg::locatingGate] = new LocateGate();
     subroutines_[worldstate::StateMsg::aligningWithGate] = new LineUpWithGate();
     subroutines_[worldstate::StateMsg::passingGate] = new GoThroughGate();
+
+    running_ = subroutines_[worldstate::StateMsg::locatingGate];
+    running_->startup();
 }

--- a/src/decision/src/DecisionNode.cpp
+++ b/src/decision/src/DecisionNode.cpp
@@ -6,8 +6,8 @@
  * operation.
  */
 
-#include <std_msgs/String.h>
 #include "DecisionNode.h"
+#include <std_msgs/String.h>
 
 DecisionNode::DecisionNode(int argc, char** argv, std::string node_name) {
     ros::init(argc, argv, node_name);

--- a/src/decision/src/DecisionNode.cpp
+++ b/src/decision/src/DecisionNode.cpp
@@ -15,7 +15,7 @@ DecisionNode::DecisionNode(int argc, char** argv, std::string node_name) {
 
     setupSubroutineMap();
 
-    std::string state_topic = "worldstate";
+    std::string state_topic = "/world_state_node/output";
     int refresh_rate        = 10;
     worldstate_subscriber_  = nh.subscribe(
     state_topic, refresh_rate, &DecisionNode::worldStateCallback, this);

--- a/src/decision/src/DecisionNode.cpp
+++ b/src/decision/src/DecisionNode.cpp
@@ -56,9 +56,9 @@ const worldstate::StateMsg::ConstPtr& StateMsg) {
  * subroutine
  */
 void DecisionNode::setupSubroutineMap() {
-    subroutines_[worldstate::StateMsg::locatingGate] = new LocateGate();
+    subroutines_[worldstate::StateMsg::locatingGate]     = new LocateGate();
     subroutines_[worldstate::StateMsg::aligningWithGate] = new LineUpWithGate();
-    subroutines_[worldstate::StateMsg::passingGate] = new GoThroughGate();
+    subroutines_[worldstate::StateMsg::passingGate]      = new GoThroughGate();
 
     running_ = subroutines_[worldstate::StateMsg::locatingGate];
     running_->startup();

--- a/src/decision/src/DecisionNode.cpp
+++ b/src/decision/src/DecisionNode.cpp
@@ -6,6 +6,7 @@
  * operation.
  */
 
+#include <std_msgs/String.h>
 #include "DecisionNode.h"
 
 DecisionNode::DecisionNode(int argc, char** argv, std::string node_name) {
@@ -19,6 +20,8 @@ DecisionNode::DecisionNode(int argc, char** argv, std::string node_name) {
     int refresh_rate        = 10;
     worldstate_subscriber_  = nh.subscribe(
     state_topic, refresh_rate, &DecisionNode::worldStateCallback, this);
+
+    info_publisher_ = private_nh.advertise<std_msgs::String>("info", 1);
 }
 
 /**
@@ -45,6 +48,10 @@ const worldstate::StateMsg::ConstPtr& StateMsg) {
         running_ = newState;
         running_->startup();
     }
+
+    std_msgs::String info;
+    info.data = running_->getName();
+    info_publisher_.publish(info);
 }
 
 /**

--- a/src/decision/src/DecisionNode.cpp
+++ b/src/decision/src/DecisionNode.cpp
@@ -13,7 +13,7 @@ DecisionNode::DecisionNode(int argc, char** argv, std::string node_name) {
     ros::NodeHandle nh;
     ros::NodeHandle private_nh("~");
 
-    setupSubroutineMap(argc, argv);
+    setupSubroutineMap();
 
     std::string state_topic = "worldstate";
     int refresh_rate        = 10;
@@ -53,7 +53,7 @@ const worldstate::StateMsg::ConstPtr& StateMsg) {
  * @param argv standard argv passed in from main, used for the ros::init of each
  * subroutine
  */
-void DecisionNode::setupSubroutineMap(int argc, char** argv) {
+void DecisionNode::setupSubroutineMap() {
     subroutines_[worldstate::StateMsg::locatingGate] = new LocateGate();
     subroutines_[worldstate::StateMsg::aligningWithGate] = new LineUpWithGate();
     subroutines_[worldstate::StateMsg::passingGate] = new GoThroughGate();

--- a/src/decision/src/decision_node.cpp
+++ b/src/decision/src/decision_node.cpp
@@ -10,7 +10,7 @@
 
 int main(int argc, char** argv) {
     // Setup your ROS node
-    std::string node_name = "filter";
+    std::string node_name = "decision";
 
     // Create an instance of your class
     DecisionNode decisionNode(argc, argv, node_name);

--- a/src/decision/src/subroutines/Subroutine.cpp
+++ b/src/decision/src/subroutines/Subroutine.cpp
@@ -9,19 +9,19 @@
 Subroutine::Subroutine() {}
 
 void Subroutine::startup() {
-    nh_         = ros::NodeHandle();
-    private_nh_ = ros::NodeHandle("~");
+    ros::NodeHandle nh;
+    ros::NodeHandle private_nh("~");
 
-    setupSubscriptions(nh_);
+    setupSubscriptions(nh);
 
-    std::string topic   = private_nh_.resolveName("sub_control");
+    std::string topic   = private_nh.resolveName("output");
     uint32_t queue_size = 10;
-    publisher_ = private_nh_.advertise<geometry_msgs::Twist>(topic, queue_size);
+    publisher_ = private_nh.advertise<geometry_msgs::Twist>(topic, queue_size);
 }
 
 void Subroutine::shutdown() {
-    nh_.shutdown();
-    private_nh_.shutdown();
+    publisher_.shutdown();
+    subscriber_.shutdown();
 }
 
 void Subroutine::publishCommand(const geometry_msgs::Twist& msg) {

--- a/src/decision/src/subroutines/Subroutine.cpp
+++ b/src/decision/src/subroutines/Subroutine.cpp
@@ -22,8 +22,7 @@ void Subroutine::startup() {
 void Subroutine::shutdown() {
     publisher_.shutdown();
 
-    for (ros::Subscriber subscription : subscriptions_)
-    {
+    for (ros::Subscriber subscription : subscriptions_) {
         subscription.shutdown();
     }
     subscriptions_.clear();

--- a/src/decision/src/subroutines/Subroutine.cpp
+++ b/src/decision/src/subroutines/Subroutine.cpp
@@ -16,7 +16,7 @@ void Subroutine::startup() {
     setupSubscriptions(nh_);
 
     std::string topic   = private_nh_.resolveName("sub_control");
-    uint32_t queue_size = 1;
+    uint32_t queue_size = 10;
     publisher_ = private_nh_.advertise<geometry_msgs::Twist>(topic, queue_size);
 }
 

--- a/src/decision/src/subroutines/Subroutine.cpp
+++ b/src/decision/src/subroutines/Subroutine.cpp
@@ -21,7 +21,12 @@ void Subroutine::startup() {
 
 void Subroutine::shutdown() {
     publisher_.shutdown();
-    subscriber_.shutdown();
+
+    for (ros::Subscriber subscription : subscriptions_)
+    {
+        subscription.shutdown();
+    }
+    subscriptions_.clear();
 }
 
 void Subroutine::publishCommand(const geometry_msgs::Twist& msg) {

--- a/src/decision/src/subroutines/Subroutine.cpp
+++ b/src/decision/src/subroutines/Subroutine.cpp
@@ -12,7 +12,7 @@ void Subroutine::startup() {
     ros::NodeHandle nh;
     ros::NodeHandle private_nh("~");
 
-    setupSubscriptions(nh);
+    subscriptions_ = getSubscriptions(nh);
 
     std::string topic   = private_nh.resolveName("output");
     uint32_t queue_size = 10;

--- a/src/decision/src/subroutines/Subroutine.cpp
+++ b/src/decision/src/subroutines/Subroutine.cpp
@@ -6,11 +6,10 @@
 
 #include "Subroutine.h"
 
-Subroutine::Subroutine() {
-}
+Subroutine::Subroutine() {}
 
 void Subroutine::startup() {
-    nh_ = ros::NodeHandle();
+    nh_         = ros::NodeHandle();
     private_nh_ = ros::NodeHandle("~");
 
     setupSubscriptions(nh_);

--- a/src/decision/src/subroutines/Subroutine.cpp
+++ b/src/decision/src/subroutines/Subroutine.cpp
@@ -6,22 +6,23 @@
 
 #include "Subroutine.h"
 
-Subroutine::Subroutine(int argc, char** argv, std::string node_name) {
-    ros::init(argc, argv, node_name);
+Subroutine::Subroutine() {
 }
 
 void Subroutine::startup() {
-    ros::NodeHandle nh;
-    setupSubscriptions(nh);
+    nh_ = ros::NodeHandle();
+    private_nh_ = ros::NodeHandle("~");
 
-    ros::NodeHandle private_nh("~");
-    std::string topic   = private_nh.resolveName("sub_control");
+    setupSubscriptions(nh_);
+
+    std::string topic   = private_nh_.resolveName("sub_control");
     uint32_t queue_size = 1;
-    publisher_ = private_nh.advertise<geometry_msgs::Twist>(topic, queue_size);
+    publisher_ = private_nh_.advertise<geometry_msgs::Twist>(topic, queue_size);
 }
 
 void Subroutine::shutdown() {
-    ros::shutdown();
+    nh_.shutdown();
+    private_nh_.shutdown();
 }
 
 void Subroutine::publishCommand(const geometry_msgs::Twist& msg) {

--- a/src/decision/src/subroutines/gate/GoThroughGate.cpp
+++ b/src/decision/src/subroutines/gate/GoThroughGate.cpp
@@ -6,9 +6,11 @@
 
 #include "GoThroughGate.h"
 
-void GoThroughGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriptions_.push_back(
-    nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this));
+std::vector<ros::Subscriber> GoThroughGate::getSubscriptions(ros::NodeHandle nh) {
+    std::vector<ros::Subscriber> subs;
+    subs.push_back(
+            nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this));
+    return subs;
 }
 
 void GoThroughGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/GoThroughGate.cpp
+++ b/src/decision/src/subroutines/gate/GoThroughGate.cpp
@@ -7,8 +7,7 @@
 #include "GoThroughGate.h"
 
 void GoThroughGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriber_ =
-    nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this);
+    subscriptions_.push_back(nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this));
 }
 
 void GoThroughGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/GoThroughGate.cpp
+++ b/src/decision/src/subroutines/gate/GoThroughGate.cpp
@@ -6,10 +6,11 @@
 
 #include "GoThroughGate.h"
 
-std::vector<ros::Subscriber> GoThroughGate::getSubscriptions(ros::NodeHandle nh) {
+std::vector<ros::Subscriber>
+GoThroughGate::getSubscriptions(ros::NodeHandle nh) {
     std::vector<ros::Subscriber> subs;
     subs.push_back(
-            nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this));
+    nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this));
     return subs;
 }
 

--- a/src/decision/src/subroutines/gate/GoThroughGate.cpp
+++ b/src/decision/src/subroutines/gate/GoThroughGate.cpp
@@ -7,7 +7,8 @@
 #include "GoThroughGate.h"
 
 void GoThroughGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriptions_.push_back(nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this));
+    subscriptions_.push_back(
+    nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this));
 }
 
 void GoThroughGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/GoThroughGate.cpp
+++ b/src/decision/src/subroutines/gate/GoThroughGate.cpp
@@ -7,7 +7,8 @@
 #include "GoThroughGate.h"
 
 void GoThroughGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriber_ = nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this);
+    subscriber_ =
+    nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this);
 }
 
 void GoThroughGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/GoThroughGate.cpp
+++ b/src/decision/src/subroutines/gate/GoThroughGate.cpp
@@ -7,7 +7,7 @@
 #include "GoThroughGate.h"
 
 void GoThroughGate::setupSubscriptions(ros::NodeHandle nh) {
-    nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this);
+    subscriber_ = nh.subscribe("gate_location", 10, &GoThroughGate::decisionCallback, this);
 }
 
 void GoThroughGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/LineUpWithGate.cpp
+++ b/src/decision/src/subroutines/gate/LineUpWithGate.cpp
@@ -7,9 +7,11 @@
 
 #include "LineUpWithGate.h"
 
-void LineUpWithGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriptions_.push_back(
-    nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this));
+std::vector<ros::Subscriber> LineUpWithGate::getSubscriptions(ros::NodeHandle nh) {
+    std::vector<ros::Subscriber> subs;
+    subs.push_back(
+            nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this));
+    return subs;
 }
 
 void LineUpWithGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/LineUpWithGate.cpp
+++ b/src/decision/src/subroutines/gate/LineUpWithGate.cpp
@@ -9,8 +9,9 @@
 #include "constants.h"
 
 void LineUpWithGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriber_ = nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this);
-//    nh.subscribe("imu", 10, &LineUpWithGate::balance, this);
+    subscriber_ =
+    nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this);
+    //    nh.subscribe("imu", 10, &LineUpWithGate::balance, this);
 }
 
 void LineUpWithGate::balance(const geometry_msgs::Twist::ConstPtr& msg) {

--- a/src/decision/src/subroutines/gate/LineUpWithGate.cpp
+++ b/src/decision/src/subroutines/gate/LineUpWithGate.cpp
@@ -9,8 +9,8 @@
 #include "constants.h"
 
 void LineUpWithGate::setupSubscriptions(ros::NodeHandle nh) {
-    nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this);
-    nh.subscribe("imu", 10, &LineUpWithGate::balance, this);
+    subscriber_ = nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this);
+//    nh.subscribe("imu", 10, &LineUpWithGate::balance, this);
 }
 
 void LineUpWithGate::balance(const geometry_msgs::Twist::ConstPtr& msg) {

--- a/src/decision/src/subroutines/gate/LineUpWithGate.cpp
+++ b/src/decision/src/subroutines/gate/LineUpWithGate.cpp
@@ -35,9 +35,8 @@ const gate_detect::gateDetectMsg::ConstPtr& msg) {
         double averageDistanceToGate;
 
         averageDistanceToGate =
-                (msg->distanceLeft + msg->distanceRight +
-                 msg->distanceTop) /
-                (msg->detectLeft + msg->detectRight + msg->detectTop);
+        (msg->distanceLeft + msg->distanceRight + msg->distanceTop) /
+        (msg->detectLeft + msg->detectRight + msg->detectTop);
 
         if (averageDistanceToGate > 7) {
             if (msg->angleTop > 0.25) {

--- a/src/decision/src/subroutines/gate/LineUpWithGate.cpp
+++ b/src/decision/src/subroutines/gate/LineUpWithGate.cpp
@@ -8,7 +8,8 @@
 #include "LineUpWithGate.h"
 
 void LineUpWithGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriptions_.push_back(nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this));
+    subscriptions_.push_back(
+    nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this));
 }
 
 void LineUpWithGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/LineUpWithGate.cpp
+++ b/src/decision/src/subroutines/gate/LineUpWithGate.cpp
@@ -6,16 +6,9 @@
  */
 
 #include "LineUpWithGate.h"
-#include "constants.h"
 
 void LineUpWithGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriber_ =
-    nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this);
-    //    nh.subscribe("imu", 10, &LineUpWithGate::balance, this);
-}
-
-void LineUpWithGate::balance(const geometry_msgs::Twist::ConstPtr& msg) {
-    // if not parallel with ground, become parallel with ground
+    subscriptions_.push_back(nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this));
 }
 
 void LineUpWithGate::decisionCallback(
@@ -32,7 +25,7 @@ const gate_detect::gateDetectMsg::ConstPtr& msg) {
 
     geometry_msgs::Twist command;
 
-    if (!distanceToGateAcceptable_) {
+    if (!distance_to_gate_acceptable_) {
         double averageDistanceToGate;
 
         averageDistanceToGate =
@@ -53,11 +46,11 @@ const gate_detect::gateDetectMsg::ConstPtr& msg) {
                 command.linear.x = FORWARD;
             }
         } else {
-            distanceToGateAcceptable_ = true;
+            distance_to_gate_acceptable_ = true;
         }
     }
 
-    if (!allignTop_) {
+    if (!align_top_) {
         if (msg->angleTop > 0.25) {
             command.linear.z = DOWN;
             publishCommand(command);
@@ -67,7 +60,7 @@ const gate_detect::gateDetectMsg::ConstPtr& msg) {
             publishCommand(command);
             return;
         } else {
-            allignTop_ = true;
+            align_top_ = true;
         }
     }
 

--- a/src/decision/src/subroutines/gate/LineUpWithGate.cpp
+++ b/src/decision/src/subroutines/gate/LineUpWithGate.cpp
@@ -7,10 +7,11 @@
 
 #include "LineUpWithGate.h"
 
-std::vector<ros::Subscriber> LineUpWithGate::getSubscriptions(ros::NodeHandle nh) {
+std::vector<ros::Subscriber>
+LineUpWithGate::getSubscriptions(ros::NodeHandle nh) {
     std::vector<ros::Subscriber> subs;
     subs.push_back(
-            nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this));
+    nh.subscribe("gate_location", 10, &LineUpWithGate::decisionCallback, this));
     return subs;
 }
 

--- a/src/decision/src/subroutines/gate/LocateGate.cpp
+++ b/src/decision/src/subroutines/gate/LocateGate.cpp
@@ -7,9 +7,11 @@
 
 #include "LocateGate.h"
 
-void LocateGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriptions_.push_back(
-    nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this));
+std::vector<ros::Subscriber> LocateGate::getSubscriptions(ros::NodeHandle nh) {
+    std::vector<ros::Subscriber> subs;
+    subs.push_back(
+            nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this));
+    return subs;
 }
 
 void LocateGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/LocateGate.cpp
+++ b/src/decision/src/subroutines/gate/LocateGate.cpp
@@ -8,7 +8,8 @@
 #include "LocateGate.h"
 
 void LocateGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriber_ = nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this);
+    subscriber_ =
+    nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this);
 }
 
 void LocateGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/LocateGate.cpp
+++ b/src/decision/src/subroutines/gate/LocateGate.cpp
@@ -8,7 +8,8 @@
 #include "LocateGate.h"
 
 void LocateGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriptions_.push_back(nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this));
+    subscriptions_.push_back(
+    nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this));
 }
 
 void LocateGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/LocateGate.cpp
+++ b/src/decision/src/subroutines/gate/LocateGate.cpp
@@ -8,7 +8,7 @@
 #include "LocateGate.h"
 
 void LocateGate::setupSubscriptions(ros::NodeHandle nh) {
-    nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this);
+    subscriber_ = nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this);
 }
 
 void LocateGate::decisionCallback(

--- a/src/decision/src/subroutines/gate/LocateGate.cpp
+++ b/src/decision/src/subroutines/gate/LocateGate.cpp
@@ -10,7 +10,7 @@
 std::vector<ros::Subscriber> LocateGate::getSubscriptions(ros::NodeHandle nh) {
     std::vector<ros::Subscriber> subs;
     subs.push_back(
-            nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this));
+    nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this));
     return subs;
 }
 

--- a/src/decision/src/subroutines/gate/LocateGate.cpp
+++ b/src/decision/src/subroutines/gate/LocateGate.cpp
@@ -8,8 +8,7 @@
 #include "LocateGate.h"
 
 void LocateGate::setupSubscriptions(ros::NodeHandle nh) {
-    subscriber_ =
-    nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this);
+    subscriptions_.push_back(nh.subscribe("gate_location", 10, &LocateGate::decisionCallback, this));
 }
 
 void LocateGate::decisionCallback(

--- a/src/decision/test/decision_node_rostest.cpp
+++ b/src/decision/test/decision_node_rostest.cpp
@@ -8,9 +8,9 @@
 
 #include "DecisionNode.h"
 
+#include "LocateGate.h"
 #include <gtest/gtest.h>
 #include <std_msgs/String.h>
-#include "LocateGate.h"
 
 class DecisionNodeTest : public testing::Test {
   protected:
@@ -31,9 +31,7 @@ class DecisionNodeTest : public testing::Test {
     std::string message_output = "";
 
   public:
-    void callback(const std_msgs::String msg) {
-        message_output = msg.data;
-    }
+    void callback(const std_msgs::String msg) { message_output = msg.data; }
 };
 
 TEST_F(DecisionNodeTest, decisionNode_transition_test) {

--- a/src/decision/test/decision_node_rostest.cpp
+++ b/src/decision/test/decision_node_rostest.cpp
@@ -1,0 +1,68 @@
+/*
+ *  Author: Joel Ahn
+ *  Date:  31/03/18
+ *  Purpose: Creates a dummy node to publish and subscribe to the relevant
+ *           world_state_node topics to determine that the correct values
+ *           are being outputted.
+ */
+
+#include "DecisionNode.h"
+
+#include <gtest/gtest.h>
+#include <std_msgs/String.h>
+#include "LocateGate.h"
+
+class DecisionNodeTest : public testing::Test {
+  protected:
+    virtual void SetUp() {
+        test_publisher =
+        nh_.advertise<worldstate::StateMsg>("/world_state_node/output", 1);
+        test_subscriber = nh_.subscribe(
+        "/decision_node/info", 1, &DecisionNodeTest::callback, this);
+
+        // Let the publishers and subscribers set itself up timely
+        ros::Rate loop_rate(1);
+        loop_rate.sleep();
+    }
+
+    ros::NodeHandle nh_;
+    ros::Publisher test_publisher;
+    ros::Subscriber test_subscriber;
+    std::string message_output = "";
+
+  public:
+    void callback(const std_msgs::String msg) {
+        message_output = msg.data;
+    }
+};
+
+TEST_F(DecisionNodeTest, decisionNode_transition_test) {
+    worldstate::StateMsg msg;
+    msg.state = msg.locatingGate;
+
+    test_publisher.publish(msg);
+
+    ros::Rate loop_rate(1);
+    loop_rate.sleep();
+    ros::spinOnce();
+
+    std_msgs::String buf;
+    buf.data = "LocateGate";
+
+    EXPECT_EQ(buf.data, message_output);
+
+    msg.state = msg.aligningWithGate;
+
+    test_publisher.publish(msg);
+    loop_rate.sleep();
+    ros::spinOnce();
+    buf.data = "LineUpWithGate";
+
+    EXPECT_EQ(buf.data, message_output);
+}
+
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "decision_node_rostest");
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/decision/test/decision_node_test.test
+++ b/src/decision/test/decision_node_test.test
@@ -1,0 +1,6 @@
+<!-- A .test file which launches the node and its corresponding rostest -->
+
+<launch>
+    <node name="decision_node" pkg="decision" type="decision_node" />
+    <test test-name="decision_node_rostest" pkg="decision" type="decision_node_rostest" />
+</launch>

--- a/src/worldstate/include/WorldStateNode.h
+++ b/src/worldstate/include/WorldStateNode.h
@@ -38,7 +38,7 @@ class WorldStateNode {
     /**
      * Instantiate each of the individual routine nodes in ros shutdown mode
      */
-    void initializeFiniteStateMachine(int argc, char** argv);
+    void initializeFiniteStateMachine();
 };
 
 #endif // JORMUNGANDR_WORLDSTATENODE_H

--- a/src/worldstate/include/routines/Gate/AlignWithGate.h
+++ b/src/worldstate/include/routines/Gate/AlignWithGate.h
@@ -15,14 +15,10 @@
 /*** Communicating Class {alignWithGate, locatingGate, passGate} ***/
 class AlignWithGate : public State {
   public:
-    AlignWithGate(int argc, char** argv, std::string node_name)
-      : State(argc, argv, node_name) {}
+    AlignWithGate() : State() {}
     void setupNodeSubscriptions(ros::NodeHandle nh) override;
-    void sleep() override;
 
   private:
-    ros::Subscriber gate_detect_listener_;
-
     /**
      * Decides based on image data whether the robot still needs to
      * align with the gate.

--- a/src/worldstate/include/routines/Gate/AlignWithGate.h
+++ b/src/worldstate/include/routines/Gate/AlignWithGate.h
@@ -16,7 +16,7 @@
 class AlignWithGate : public State {
   public:
     AlignWithGate() : State() {}
-    void setupNodeSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber> getNodeSubscriptions(ros::NodeHandle nh) override;
 
   private:
     /**

--- a/src/worldstate/include/routines/Gate/AlignWithGate.h
+++ b/src/worldstate/include/routines/Gate/AlignWithGate.h
@@ -16,7 +16,8 @@
 class AlignWithGate : public State {
   public:
     AlignWithGate() : State() {}
-    std::vector<ros::Subscriber> getNodeSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber>
+    getNodeSubscriptions(ros::NodeHandle nh) override;
 
   private:
     /**

--- a/src/worldstate/include/routines/Gate/LocatingGate.h
+++ b/src/worldstate/include/routines/Gate/LocatingGate.h
@@ -16,7 +16,8 @@
 class LocatingGate : public State {
   public:
     LocatingGate() : State() {}
-    std::vector<ros::Subscriber> getNodeSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber>
+    getNodeSubscriptions(ros::NodeHandle nh) override;
 
   private:
     /**

--- a/src/worldstate/include/routines/Gate/LocatingGate.h
+++ b/src/worldstate/include/routines/Gate/LocatingGate.h
@@ -16,7 +16,7 @@
 class LocatingGate : public State {
   public:
     LocatingGate() : State() {}
-    void setupNodeSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber> getNodeSubscriptions(ros::NodeHandle nh) override;
 
   private:
     /**

--- a/src/worldstate/include/routines/Gate/LocatingGate.h
+++ b/src/worldstate/include/routines/Gate/LocatingGate.h
@@ -15,14 +15,10 @@
 /*** Communicating Class {alignWithGate, locatingGate, passGate} ***/
 class LocatingGate : public State {
   public:
-    LocatingGate(int argc, char** argv, std::string node_name)
-      : State(argc, argv, node_name) {}
+    LocatingGate() : State() {}
     void setupNodeSubscriptions(ros::NodeHandle nh) override;
-    void sleep() override;
 
   private:
-    ros::Subscriber gate_detect_listener_;
-
     /**
      * Decides based on image data whether the robot still needs to
      * align with the gate.

--- a/src/worldstate/include/routines/Gate/PassGate.h
+++ b/src/worldstate/include/routines/Gate/PassGate.h
@@ -16,8 +16,7 @@
 class PassGate : public State {
   public:
     PassGate() : State() {}
-
-    void setupNodeSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber> getNodeSubscriptions(ros::NodeHandle nh) override;
 
   private:
     /**

--- a/src/worldstate/include/routines/Gate/PassGate.h
+++ b/src/worldstate/include/routines/Gate/PassGate.h
@@ -16,7 +16,8 @@
 class PassGate : public State {
   public:
     PassGate() : State() {}
-    std::vector<ros::Subscriber> getNodeSubscriptions(ros::NodeHandle nh) override;
+    std::vector<ros::Subscriber>
+    getNodeSubscriptions(ros::NodeHandle nh) override;
 
   private:
     /**

--- a/src/worldstate/include/routines/Gate/PassGate.h
+++ b/src/worldstate/include/routines/Gate/PassGate.h
@@ -15,16 +15,11 @@
 /*** Communicating Class {alignWithGate, locatingGate, passGate} ***/
 class PassGate : public State {
   public:
-    PassGate(int argc, char** argv, std::string node_name)
-      : State(argc, argv, node_name) {}
+    PassGate() : State() {}
 
     void setupNodeSubscriptions(ros::NodeHandle nh) override;
-    void sleep() override;
 
   private:
-    ros::Subscriber gate_detect_listener;
-    // ros::Subscriber imu_listener_;
-
     /**
      * Decides based on image data whether the robot still needs to
      * align with the gate.

--- a/src/worldstate/include/routines/State.h
+++ b/src/worldstate/include/routines/State.h
@@ -16,6 +16,7 @@ class State {
     // hold onto these, automatically unsubscribe/unadvertise when out of scope
     ros::Publisher state_publisher_;
     std::vector<ros::Subscriber> subscriptions_;
+
   public:
     State();
 
@@ -47,7 +48,8 @@ class State {
      *
      * @param nh the private nodehandle of the State
      */
-    virtual std::vector<ros::Subscriber> getNodeSubscriptions(ros::NodeHandle nh) = 0;
+    virtual std::vector<ros::Subscriber>
+    getNodeSubscriptions(ros::NodeHandle nh) = 0;
 };
 
 #endif // PROJECT_ROUTINE_H

--- a/src/worldstate/include/routines/State.h
+++ b/src/worldstate/include/routines/State.h
@@ -28,10 +28,9 @@ class State {
     void sleep();
 
   protected:
+    // hold onto these, automatically unsubscribe/unadvertise when out of scope
     ros::Publisher state_publisher_;
-    // used to set up and tear down state specific subscriptions
-    ros::NodeHandle nh_;
-    ros::NodeHandle private_nh_;
+    ros::Subscriber subscriber_;
 
     /**
      * Publishes the next state in the finite state machine

--- a/src/worldstate/include/routines/State.h
+++ b/src/worldstate/include/routines/State.h
@@ -30,7 +30,7 @@ class State {
   protected:
     // hold onto these, automatically unsubscribe/unadvertise when out of scope
     ros::Publisher state_publisher_;
-    ros::Subscriber subscriber_;
+    std::vector<ros::Subscriber> subscriptions_;
 
     /**
      * Publishes the next state in the finite state machine

--- a/src/worldstate/include/routines/State.h
+++ b/src/worldstate/include/routines/State.h
@@ -12,6 +12,10 @@
 #include <worldstate/StateMsg.h>
 
 class State {
+  private:
+    // hold onto these, automatically unsubscribe/unadvertise when out of scope
+    ros::Publisher state_publisher_;
+    std::vector<ros::Subscriber> subscriptions_;
   public:
     State();
 
@@ -28,10 +32,6 @@ class State {
     void sleep();
 
   protected:
-    // hold onto these, automatically unsubscribe/unadvertise when out of scope
-    ros::Publisher state_publisher_;
-    std::vector<ros::Subscriber> subscriptions_;
-
     /**
      * Publishes the next state in the finite state machine
      * to transition to
@@ -47,7 +47,7 @@ class State {
      *
      * @param nh the private nodehandle of the State
      */
-    virtual void setupNodeSubscriptions(ros::NodeHandle nh) = 0;
+    virtual std::vector<ros::Subscriber> getNodeSubscriptions(ros::NodeHandle nh) = 0;
 };
 
 #endif // PROJECT_ROUTINE_H

--- a/src/worldstate/include/routines/State.h
+++ b/src/worldstate/include/routines/State.h
@@ -13,7 +13,7 @@
 
 class State {
   public:
-    State(int argc, char** argv, std::string node_name);
+    State();
 
     /**
      * Initializes and starts the state's callback functions
@@ -25,10 +25,13 @@ class State {
      * Deactivates a node by shutting down its subscriber
      * so that its callback functions are no longer active
      */
-    virtual void sleep() = 0;
+    void sleep();
 
   protected:
     ros::Publisher state_publisher_;
+    // used to set up and tear down state specific subscriptions
+    ros::NodeHandle nh_;
+    ros::NodeHandle private_nh_;
 
     /**
      * Publishes the next state in the finite state machine

--- a/src/worldstate/src/WorldStateNode.cpp
+++ b/src/worldstate/src/WorldStateNode.cpp
@@ -12,7 +12,7 @@
 #include <WorldStateNode.h>
 
 WorldStateNode::WorldStateNode(int argc, char** argv, std::string node_name) {
-    WorldStateNode::initializeFiniteStateMachine(argc, argv);
+    WorldStateNode::initializeFiniteStateMachine();
 
     // Setup NodeHandles
     ros::init(argc, argv, node_name);
@@ -55,15 +55,10 @@ const worldstate::StateMsg::ConstPtr& msg) {
  * @param argv standard argv passed in from main, used for the ros::init of each
  * subroutine
  */
-void WorldStateNode::initializeFiniteStateMachine(int argc, char** argv) {
-    state_machine_[worldstate::StateMsg::locatingGate] =
-    new LocatingGate(argc, argv, "locating_gate_ws");
-
-    state_machine_[worldstate::StateMsg::aligningWithGate] =
-    new AlignWithGate(argc, argv, "aligning_with_gate_ws");
-
-    state_machine_[worldstate::StateMsg::passingGate] =
-    new PassGate(argc, argv, "passing_thru_gate_ws");
+void WorldStateNode::initializeFiniteStateMachine() {
+    state_machine_[worldstate::StateMsg::locatingGate] = new LocatingGate();
+    state_machine_[worldstate::StateMsg::aligningWithGate] = new AlignWithGate();
+    state_machine_[worldstate::StateMsg::passingGate] = new PassGate();
 
     // Activate the state_machine with the initial state
     current_state_ = state_machine_[initial_state_];

--- a/src/worldstate/src/WorldStateNode.cpp
+++ b/src/worldstate/src/WorldStateNode.cpp
@@ -57,7 +57,8 @@ const worldstate::StateMsg::ConstPtr& msg) {
  */
 void WorldStateNode::initializeFiniteStateMachine() {
     state_machine_[worldstate::StateMsg::locatingGate] = new LocatingGate();
-    state_machine_[worldstate::StateMsg::aligningWithGate] = new AlignWithGate();
+    state_machine_[worldstate::StateMsg::aligningWithGate] =
+    new AlignWithGate();
     state_machine_[worldstate::StateMsg::passingGate] = new PassGate();
 
     // Activate the state_machine with the initial state

--- a/src/worldstate/src/WorldStateNode.cpp
+++ b/src/worldstate/src/WorldStateNode.cpp
@@ -12,14 +12,14 @@
 #include <WorldStateNode.h>
 
 WorldStateNode::WorldStateNode(int argc, char** argv, std::string node_name) {
+    ros::init(argc, argv, node_name);
     WorldStateNode::initializeFiniteStateMachine();
 
     // Setup NodeHandles
-    ros::init(argc, argv, node_name);
     ros::NodeHandle nh;
 
     // Change the subscribe topics as needed
-    std::string state_transition_msg = "worldstate/output";
+    std::string state_transition_msg = "/world_state_node/output";
     uint32_t refresh_rate            = 10;
     world_state_listener_            = nh.subscribe(state_transition_msg,
                                          refresh_rate,

--- a/src/worldstate/src/routines/Gate/AlignWithGate.cpp
+++ b/src/worldstate/src/routines/Gate/AlignWithGate.cpp
@@ -10,7 +10,8 @@
 
 void AlignWithGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriber_ = nh.subscribe(gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this);
+    subscriber_ =
+    nh.subscribe(gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this);
 }
 
 void AlignWithGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/AlignWithGate.cpp
+++ b/src/worldstate/src/routines/Gate/AlignWithGate.cpp
@@ -8,7 +8,8 @@
 #include "AlignWithGate.h"
 #include <worldstate/StateMsg.h>
 
-std::vector<ros::Subscriber> AlignWithGate::getNodeSubscriptions(ros::NodeHandle nh) {
+std::vector<ros::Subscriber>
+AlignWithGate::getNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
 
     std::vector<ros::Subscriber> subs;

--- a/src/worldstate/src/routines/Gate/AlignWithGate.cpp
+++ b/src/worldstate/src/routines/Gate/AlignWithGate.cpp
@@ -10,8 +10,7 @@
 
 void AlignWithGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriber_ =
-    nh.subscribe(gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this);
+    subscriptions_.push_back(nh.subscribe(gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this));
 }
 
 void AlignWithGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/AlignWithGate.cpp
+++ b/src/worldstate/src/routines/Gate/AlignWithGate.cpp
@@ -10,12 +10,7 @@
 
 void AlignWithGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    gate_detect_listener_ =
     nh.subscribe(gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this);
-}
-
-void AlignWithGate::sleep() {
-    gate_detect_listener_.shutdown();
 }
 
 void AlignWithGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/AlignWithGate.cpp
+++ b/src/worldstate/src/routines/Gate/AlignWithGate.cpp
@@ -8,10 +8,13 @@
 #include "AlignWithGate.h"
 #include <worldstate/StateMsg.h>
 
-void AlignWithGate::setupNodeSubscriptions(ros::NodeHandle nh) {
+std::vector<ros::Subscriber> AlignWithGate::getNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriptions_.push_back(nh.subscribe(
+
+    std::vector<ros::Subscriber> subs;
+    subs.push_back(nh.subscribe(
     gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this));
+    return subs;
 }
 
 void AlignWithGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/AlignWithGate.cpp
+++ b/src/worldstate/src/routines/Gate/AlignWithGate.cpp
@@ -10,7 +10,8 @@
 
 void AlignWithGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriptions_.push_back(nh.subscribe(gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this));
+    subscriptions_.push_back(nh.subscribe(
+    gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this));
 }
 
 void AlignWithGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/AlignWithGate.cpp
+++ b/src/worldstate/src/routines/Gate/AlignWithGate.cpp
@@ -10,7 +10,7 @@
 
 void AlignWithGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    nh.subscribe(gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this);
+    subscriber_ = nh.subscribe(gateDetectTopic, 10, &AlignWithGate::gateDetectCallBack, this);
 }
 
 void AlignWithGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/LocatingGate.cpp
+++ b/src/worldstate/src/routines/Gate/LocatingGate.cpp
@@ -8,7 +8,8 @@
 #include "LocatingGate.h"
 #include <worldstate/StateMsg.h>
 
-std::vector<ros::Subscriber> LocatingGate::getNodeSubscriptions(ros::NodeHandle nh) {
+std::vector<ros::Subscriber>
+LocatingGate::getNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
 
     std::vector<ros::Subscriber> subs;

--- a/src/worldstate/src/routines/Gate/LocatingGate.cpp
+++ b/src/worldstate/src/routines/Gate/LocatingGate.cpp
@@ -10,7 +10,7 @@
 
 void LocatingGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this);
+    subscriber_ = nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this);
 }
 
 void LocatingGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/LocatingGate.cpp
+++ b/src/worldstate/src/routines/Gate/LocatingGate.cpp
@@ -10,8 +10,7 @@
 
 void LocatingGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriber_ =
-    nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this);
+    subscriptions_.push_back(nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this));
 }
 
 void LocatingGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/LocatingGate.cpp
+++ b/src/worldstate/src/routines/Gate/LocatingGate.cpp
@@ -10,12 +10,7 @@
 
 void LocatingGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    gate_detect_listener_ =
     nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this);
-}
-
-void LocatingGate::sleep() {
-    gate_detect_listener_.shutdown();
 }
 
 void LocatingGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/LocatingGate.cpp
+++ b/src/worldstate/src/routines/Gate/LocatingGate.cpp
@@ -10,7 +10,8 @@
 
 void LocatingGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriber_ = nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this);
+    subscriber_ =
+    nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this);
 }
 
 void LocatingGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/LocatingGate.cpp
+++ b/src/worldstate/src/routines/Gate/LocatingGate.cpp
@@ -8,10 +8,13 @@
 #include "LocatingGate.h"
 #include <worldstate/StateMsg.h>
 
-void LocatingGate::setupNodeSubscriptions(ros::NodeHandle nh) {
+std::vector<ros::Subscriber> LocatingGate::getNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriptions_.push_back(
+
+    std::vector<ros::Subscriber> subs;
+    subs.push_back(
     nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this));
+    return subs;
 }
 
 void LocatingGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/LocatingGate.cpp
+++ b/src/worldstate/src/routines/Gate/LocatingGate.cpp
@@ -10,7 +10,8 @@
 
 void LocatingGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriptions_.push_back(nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this));
+    subscriptions_.push_back(
+    nh.subscribe(gateDetectTopic, 10, &LocatingGate::gateDetectCallBack, this));
 }
 
 void LocatingGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/PassGate.cpp
+++ b/src/worldstate/src/routines/Gate/PassGate.cpp
@@ -9,7 +9,8 @@
 
 void PassGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriber_ = nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this);
+    subscriber_ =
+    nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this);
     // TODO: Use IMU to construct internal world map if need be
     // std::string imuDataTopic    = "/imu/is_calibrated";
     // nh.subscribe("/imu/is_calibrated", 10, &PassGate::imuDataCallback, this);

--- a/src/worldstate/src/routines/Gate/PassGate.cpp
+++ b/src/worldstate/src/routines/Gate/PassGate.cpp
@@ -7,7 +7,8 @@
 
 #include "PassGate.h"
 
-std::vector<ros::Subscriber> PassGate::getNodeSubscriptions(ros::NodeHandle nh) {
+std::vector<ros::Subscriber>
+PassGate::getNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
 
     std::vector<ros::Subscriber> subs;

--- a/src/worldstate/src/routines/Gate/PassGate.cpp
+++ b/src/worldstate/src/routines/Gate/PassGate.cpp
@@ -9,7 +9,7 @@
 
 void PassGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this);
+    subscriber_ = nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this);
     // TODO: Use IMU to construct internal world map if need be
     // std::string imuDataTopic    = "/imu/is_calibrated";
     // nh.subscribe("/imu/is_calibrated", 10, &PassGate::imuDataCallback, this);

--- a/src/worldstate/src/routines/Gate/PassGate.cpp
+++ b/src/worldstate/src/routines/Gate/PassGate.cpp
@@ -7,13 +7,16 @@
 
 #include "PassGate.h"
 
-void PassGate::setupNodeSubscriptions(ros::NodeHandle nh) {
+std::vector<ros::Subscriber> PassGate::getNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriptions_.push_back(
+
+    std::vector<ros::Subscriber> subs;
+    subs.push_back(
     nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this));
     // TODO: Use IMU to construct internal world map if need be
     // std::string imuDataTopic    = "/imu/is_calibrated";
     // nh.subscribe("/imu/is_calibrated", 10, &PassGate::imuDataCallback, this);
+    return subs;
 }
 
 void PassGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/Gate/PassGate.cpp
+++ b/src/worldstate/src/routines/Gate/PassGate.cpp
@@ -9,8 +9,7 @@
 
 void PassGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriber_ =
-    nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this);
+    subscriptions_.push_back(nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this));
     // TODO: Use IMU to construct internal world map if need be
     // std::string imuDataTopic    = "/imu/is_calibrated";
     // nh.subscribe("/imu/is_calibrated", 10, &PassGate::imuDataCallback, this);

--- a/src/worldstate/src/routines/Gate/PassGate.cpp
+++ b/src/worldstate/src/routines/Gate/PassGate.cpp
@@ -9,7 +9,8 @@
 
 void PassGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    subscriptions_.push_back(nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this));
+    subscriptions_.push_back(
+    nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this));
     // TODO: Use IMU to construct internal world map if need be
     // std::string imuDataTopic    = "/imu/is_calibrated";
     // nh.subscribe("/imu/is_calibrated", 10, &PassGate::imuDataCallback, this);

--- a/src/worldstate/src/routines/Gate/PassGate.cpp
+++ b/src/worldstate/src/routines/Gate/PassGate.cpp
@@ -9,15 +9,10 @@
 
 void PassGate::setupNodeSubscriptions(ros::NodeHandle nh) {
     std::string gateDetectTopic = "/gateDetect/output";
-    gate_detect_listener =
     nh.subscribe(gateDetectTopic, 10, &PassGate::gateDetectCallBack, this);
     // TODO: Use IMU to construct internal world map if need be
     // std::string imuDataTopic    = "/imu/is_calibrated";
     // nh.subscribe("/imu/is_calibrated", 10, &PassGate::imuDataCallback, this);
-}
-
-void PassGate::sleep() {
-    gate_detect_listener.shutdown();
 }
 
 void PassGate::gateDetectCallBack(

--- a/src/worldstate/src/routines/State.cpp
+++ b/src/worldstate/src/routines/State.cpp
@@ -7,24 +7,25 @@
 
 #include "routines/State.h"
 
-State::State(int argc, char** argv, std::string node_name) {
-    ros::init(argc, argv, node_name);
+State::State() {
 }
 
 void State::start() {
-    ros::NodeHandle private_nh;
+    nh_ = ros::NodeHandle();
+    private_nh_ = ros::NodeHandle("~");
 
-    setupNodeSubscriptions(private_nh);
+    setupNodeSubscriptions(nh_);
 
-    // All states should communicate with the world_state_node
-    std::string state_transition_msg =
-    private_nh.resolveName("worldstate/output");
     uint32_t queue_size_ = 10;
     // Assign the worldstate publisher
-    state_publisher_ = private_nh.advertise<worldstate::StateMsg>(
+    state_publisher_ = private_nh_.advertise<worldstate::StateMsg>(
     "worldstate/output", queue_size_);
 }
 
+void State::sleep() {
+    nh_.shutdown();
+    private_nh_.shutdown();
+}
 void State::publishNextState(const worldstate::StateMsg& msg) {
     state_publisher_.publish(msg);
 }

--- a/src/worldstate/src/routines/State.cpp
+++ b/src/worldstate/src/routines/State.cpp
@@ -13,7 +13,7 @@ void State::start() {
     ros::NodeHandle nh;
     ros::NodeHandle private_nh("~");
 
-    setupNodeSubscriptions(nh);
+    subscriptions_ = getNodeSubscriptions(nh);
 
     uint32_t queue_size_ = 10;
     // Assign the worldstate publisher

--- a/src/worldstate/src/routines/State.cpp
+++ b/src/worldstate/src/routines/State.cpp
@@ -7,11 +7,10 @@
 
 #include "routines/State.h"
 
-State::State() {
-}
+State::State() {}
 
 void State::start() {
-    nh_ = ros::NodeHandle();
+    nh_         = ros::NodeHandle();
     private_nh_ = ros::NodeHandle("~");
 
     setupNodeSubscriptions(nh_);

--- a/src/worldstate/src/routines/State.cpp
+++ b/src/worldstate/src/routines/State.cpp
@@ -23,7 +23,12 @@ void State::start() {
 
 void State::sleep() {
     state_publisher_.shutdown();
-    subscriber_.shutdown();
+
+    for (ros::Subscriber subscription : subscriptions_)
+    {
+        subscription.shutdown();
+    }
+    subscriptions_.clear();
 }
 void State::publishNextState(const worldstate::StateMsg& msg) {
     state_publisher_.publish(msg);

--- a/src/worldstate/src/routines/State.cpp
+++ b/src/worldstate/src/routines/State.cpp
@@ -17,8 +17,8 @@ void State::start() {
 
     uint32_t queue_size_ = 10;
     // Assign the worldstate publisher
-    state_publisher_ = private_nh.advertise<worldstate::StateMsg>(
-    "output", queue_size_);
+    state_publisher_ =
+    private_nh.advertise<worldstate::StateMsg>("output", queue_size_);
 }
 
 void State::sleep() {

--- a/src/worldstate/src/routines/State.cpp
+++ b/src/worldstate/src/routines/State.cpp
@@ -10,20 +10,20 @@
 State::State() {}
 
 void State::start() {
-    nh_         = ros::NodeHandle();
-    private_nh_ = ros::NodeHandle("~");
+    ros::NodeHandle nh;
+    ros::NodeHandle private_nh("~");
 
-    setupNodeSubscriptions(nh_);
+    setupNodeSubscriptions(nh);
 
     uint32_t queue_size_ = 10;
     // Assign the worldstate publisher
-    state_publisher_ = private_nh_.advertise<worldstate::StateMsg>(
-    "worldstate/output", queue_size_);
+    state_publisher_ = private_nh.advertise<worldstate::StateMsg>(
+    "output", queue_size_);
 }
 
 void State::sleep() {
-    nh_.shutdown();
-    private_nh_.shutdown();
+    state_publisher_.shutdown();
+    subscriber_.shutdown();
 }
 void State::publishNextState(const worldstate::StateMsg& msg) {
     state_publisher_.publish(msg);

--- a/src/worldstate/src/routines/State.cpp
+++ b/src/worldstate/src/routines/State.cpp
@@ -24,8 +24,7 @@ void State::start() {
 void State::sleep() {
     state_publisher_.shutdown();
 
-    for (ros::Subscriber subscription : subscriptions_)
-    {
+    for (ros::Subscriber subscription : subscriptions_) {
         subscription.shutdown();
     }
     subscriptions_.clear();

--- a/src/worldstate/test/world_state_node_rostest.cpp
+++ b/src/worldstate/test/world_state_node_rostest.cpp
@@ -17,7 +17,7 @@ class WorldStateNodeTest : public testing::Test {
         test_publisher =
         nh_.advertise<gate_detect::gateDetectMsg>("/gateDetect/output", 1);
         test_subscriber = nh_.subscribe(
-        "worldstate/output", 1, &WorldStateNodeTest::callback, this);
+        "/world_state_node/output", 1, &WorldStateNodeTest::callback, this);
 
         // Let the publishers and subscribers set itself up timely
         ros::Rate loop_rate(1);
@@ -27,7 +27,7 @@ class WorldStateNodeTest : public testing::Test {
     ros::NodeHandle nh_;
     ros::Publisher test_publisher;
     ros::Subscriber test_subscriber;
-    int message_output;
+    int message_output = -1;
 
   public:
     void callback(const worldstate::StateMsg::ConstPtr& msg) {


### PR DESCRIPTION
This is a fix for the decision maker issue of prematurely shutting down along with some code clean fixes such as removing the multiple ros::inits. I mirrored similar changes over to the worldstate as it copied that bad practice, the function of worldstate remains the same.

This also pulls in some logic changes from cam/decision_update