### PR TITLE
Cameron/fix rosinstall

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -11,3 +11,4 @@
     version: release/kinetic/usb_cam/0.3.5-0}
 - git: {local-name: external_pkg/vision_msgs, uri: 'https://github.com/Kukanani/vision_msgs.git',
     version: kinetic-devel}
+- setup-file: {local-name: /opt/ros/kinetic/setup.sh}

--- a/.rosinstall
+++ b/.rosinstall
@@ -11,4 +11,3 @@
     version: release/kinetic/usb_cam/0.3.5-0}
 - git: {local-name: external_pkg/vision_msgs, uri: 'https://github.com/Kukanani/vision_msgs.git',
     version: kinetic-devel}
-- setup-file: {local-name: /opt/ros/kinetic/setup.sh}

--- a/.rosinstall
+++ b/.rosinstall
@@ -9,4 +9,5 @@
     version: release/kinetic/phidgets_api/0.7.5-0}
 - git: {local-name: external_pkg/usb_cam, uri: 'https://github.com/ros-gbp/usb_cam-release.git',
     version: release/kinetic/usb_cam/0.3.5-0}
-- git: {local-name: external_pkg/vision_msgs, uri: 'https://github.com/Kukanani/vision_msgs.git'}
+- git: {local-name: external_pkg/vision_msgs, uri: 'https://github.com/Kukanani/vision_msgs.git',
+    version: kinetic-devel}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ matrix:
       - env: ROS_DISTRO=kinetic ROS_REPO=ros UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ubc-subbots/Jormungandr/$TRAVIS_BRANCH/.rosinstall
 
 before_script:
-    - git clone -q https://github.com/UBC-Snowbots/moveit_ci .moveit_ci
+    - git clone -q https://github.com/ubc-subbots/moveit_ci .moveit_ci
 script:
   - source .moveit_ci/travis.sh

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -28,8 +28,8 @@ rosws update
 
 # Setup rosinstall
 mkdir -p external_pkg
-rosinstall external_pkg /opt/ros/kinetic .rosinstall
-rosinstall . /opt/ros/kinetic
+rosinstall external_pkg .rosinstall
+rosinstall .
 
 # Install dependecies for external packages
 rosdep install --from-paths external_pkg --ignore-src --rosdistro kinetic -y

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -29,7 +29,7 @@ rosws update
 # Setup rosinstall
 mkdir -p external_pkg
 rosinstall external_pkg /opt/ros/kinetic .rosinstall
-rosinstall .
+rosinstall . /opt/ros/kinetic
 
 # Install dependecies for external packages
 rosdep install --from-paths external_pkg --ignore-src --rosdistro kinetic -y
@@ -55,8 +55,8 @@ echo "================================================================"
 
 sudo apt-get install -y\
     clang-format\
-    python-rosinstall
-    python-setuptools
+    python-rosinstall\
+    virtualenv
 
 sudo easy_install pip
 
@@ -111,9 +111,6 @@ echo "================================================================"
 echo "================================================================"
 echo "Staging Virtual Environment and installing python packages."
 echo "================================================================"
-
-#Installing python dependencies
-pip install virtualenv
 
 virtualenv subbots_python
 source $CURR_DIR/subbots_python/bin/activate

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -11,7 +11,7 @@
 ######################################################################
 
 echo "================================================================"
-echo "Installing ROS dependencies..."
+echo "Installing Project Dependent ROS packages."
 echo "================================================================"
 
 # Update Rosdeps
@@ -22,6 +22,21 @@ CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Clone any ros dependencies of this repo
 rosws update
+
+# Setup rosinstall
+mkdir -p external_pkg
+rosinstall external_pkg /opt/ros/kinetic .rosinstall
+rosinstall .
+
+# Install dependecies for external packages
+rosdep install --from-paths external_pkg --ignore-src --rosdistro kinetic -y
+
+# Build external packages
+catkin_make --source external_pkg
+
+echo "================================================================"
+echo "Installing ROS dependencies..."
+echo "================================================================"
 
 # Install all required dependencies to build this repo
 rosdep install --from-paths src --ignore-src --rosdistro kinetic -y
@@ -41,21 +56,6 @@ sudo apt-get install -y\
     python-setuptools
 
 sudo easy_install pip
-
-echo "================================================================"
-echo "Installing Project Dependent ROS packages."
-echo "================================================================"
-
-# Setup rosinstall
-mkdir -p external_pkg
-rosinstall external_pkg /opt/ros/kinetic .rosinstall
-rosinstall .
-
-# Install dependecies for external packages
-rosdep install --from-paths external_pkg --ignore-src --rosdistro kinetic -y
-
-# Build external packages
-catkin_make --source external_pkg
 
 echo "================================================================"
 echo "Setup .bashrc"

--- a/src/line_detect/package.xml
+++ b/src/line_detect/package.xml
@@ -18,6 +18,5 @@
   <exec_depend>image_transport</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>msg</exec_depend>
 
 </package>

--- a/src/simulator/package.xml
+++ b/src/simulator/package.xml
@@ -40,7 +40,6 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>uwsim</build_depend>
   <build_depend>uwsim_bullet</build_depend>
   <build_depend>uwsim_osgbullet</build_depend>
   <build_depend>uwsim_osgocean</build_depend>


### PR DESCRIPTION
Trying to fix some errors with our install_dependencies that I just noticed. First of all the tensorflow object detector depends on a package vision_msgs which is acquired using rosinstall. This needs to be built before we build our sources.